### PR TITLE
add ability to calibrate using buttons on car

### DIFF
--- a/car/calibration.py
+++ b/car/calibration.py
@@ -14,21 +14,22 @@ This module contains an end-to-end calibration routine for the car.
 
 from car.motors import STORE
 from car import motors as m
+from auto import console as c
+import time
 
 from cio import rpc_client as cio_rpc_client
-
-import sys
+from auto.capabilities import acquire, release
 
 
 def _query_motor_params():
     return {
-        'top'              : STORE.get('CAR_MOTOR_TOP',              40000),
-        'steering_left'    : STORE.get('CAR_MOTOR_STEERING_LEFT',     3600),
-        'steering_mid'     : STORE.get('CAR_MOTOR_STEERING_MID',      3000),
-        'steering_right'   : STORE.get('CAR_MOTOR_STEERING_RIGHT',    2400),
-        'throttle_forward' : STORE.get('CAR_MOTOR_THROTTLE_FORWARD',  4000),
-        'throttle_mid'     : STORE.get('CAR_MOTOR_THROTTLE_MID',      3000),
-        'throttle_reverse' : STORE.get('CAR_MOTOR_THROTTLE_REVERSE',  2000),
+        'top'             : STORE.get('CAR_MOTOR_TOP', 40000),
+        'steering_left'   : STORE.get('CAR_MOTOR_STEERING_LEFT', 2100),
+        'steering_mid'    : STORE.get('CAR_MOTOR_STEERING_MID', 3000),
+        'steering_right'  : STORE.get('CAR_MOTOR_STEERING_RIGHT', 4100),
+        'throttle_forward': STORE.get('CAR_MOTOR_THROTTLE_FORWARD', 4000),
+        'throttle_mid'    : STORE.get('CAR_MOTOR_THROTTLE_MID', 3000),
+        'throttle_reverse': STORE.get('CAR_MOTOR_THROTTLE_REVERSE', 2000),
     }
 
 
@@ -45,9 +46,9 @@ def _setup_motors(millisecond_timeout=1000, save=False):
 
 def _query_steering_pid_params():
     return {
-        'p':               STORE.get('CAR_STEERING_PID_P', 2.0),
-        'i':               STORE.get('CAR_STEERING_PID_I', 0.0),
-        'd':               STORE.get('CAR_STEERING_PID_D', 0.0),
+        'p'              : STORE.get('CAR_STEERING_PID_P', 2.0),
+        'i'              : STORE.get('CAR_STEERING_PID_I', 0.3),
+        'd'              : STORE.get('CAR_STEERING_PID_D', 0.3),
         'error_accum_max': STORE.get('CAR_STEERING_PID_EAM', 0.0),
     }
 
@@ -55,7 +56,7 @@ def _query_steering_pid_params():
 def _setup_steering_pid(save=False):
     steering_pid_params = _query_steering_pid_params()
     m.PID_STEERING.set_pid(
-            **steering_pid_params
+        **steering_pid_params
     )
     if save:
         m.PID_STEERING.save_pid()
@@ -66,28 +67,58 @@ def _demo_forward_reverse_no_pid(duration=1.0):
     m.drive(0.0, m.CAR_THROTTLE_REVERSE_SAFE_SPEED, duration)
 
 
-def _easy_ask(prompt, curr_val, cast_func):
-    typed = input("{} [or keep {}]: ".format(prompt, curr_val)).strip()
-    if len(typed) == 0:
-        val = curr_val
+def _easy_ask(prompt, curr_val, cast_func, io_device, adj_delta=1, min_val=None, max_val=None):
+    if io_device == 'computer':
+        result = _keyboard_input(prompt=prompt,
+                                 choices=None,
+                                 curr_val=curr_val)
+    elif io_device == 'car':
+        result = _button_numeric_input(prompt=prompt,
+                                       initial=curr_val,
+                                       adj_delta=adj_delta)
+    if result == curr_val:
+        val = result
     else:
-        val = cast_func(typed)
+        val = cast_func(result)
+        if max_val is not None:
+            val = min(val, max_val)
+        if min_val is not None:
+            val = max(val, min_val)
     return val
 
 
-def _calibrate_microcontroller():
+def _calibrate_microcontroller(io_device):
     calibrator = cio_rpc_client.acquire_component_interface('Calibrator')
-    cio_rpc_client.redirect_stdio(stdout=sys.stdout)
-    calibrator.calibrate()
-    cio_rpc_client.restore_stdio()
+    print_func = {
+        'computer': print,
+        'car'     : c.print,
+    }[io_device]
+    pinwheel = _spinning_pinwheel()
+    for status in calibrator.calibrate():
+        if status == '.':
+            print_func(f'Calibrating [{next(pinwheel)}]', end='\r')
+        else:
+            print_func(status)
+            if status == 'Finished microcontroller calibration!':
+                break
+        time.sleep(1)
     cio_rpc_client.dispose_component_interface(calibrator)
 
 
-def _calibrate_safe_throttle():
+def _spinning_pinwheel():
+    chars = list('-\\|/')
+    while True:
+        for c in chars:
+            yield c
+
+
+def _calibrate_safe_throttle(io_device):
     while True:
         # Ask user for new values.
-        safe_forward = _easy_ask("Safe forward throttle  (0, 100]", m.CAR_THROTTLE_FORWARD_SAFE_SPEED, int)
-        safe_reverse = _easy_ask("Safe reverse throttle [-100, 0)", m.CAR_THROTTLE_REVERSE_SAFE_SPEED, int)
+        safe_forward = _easy_ask("Safe forward throttle  (0, 100]", m.CAR_THROTTLE_FORWARD_SAFE_SPEED, int,
+                                 io_device, min_val=1, max_val=100)
+        safe_reverse = _easy_ask("Safe reverse throttle [-100, 0)", m.CAR_THROTTLE_REVERSE_SAFE_SPEED, int,
+                                 io_device, min_val=-100, max_val=-1)
         m.CAR_THROTTLE_FORWARD_SAFE_SPEED = safe_forward
         m.CAR_THROTTLE_REVERSE_SAFE_SPEED = safe_reverse
         STORE.put('CAR_THROTTLE_FORWARD_SAFE_SPEED', m.CAR_THROTTLE_FORWARD_SAFE_SPEED)
@@ -95,11 +126,11 @@ def _calibrate_safe_throttle():
 
         _demo_forward_reverse_no_pid()
 
-        if input("Keep? [n/y] ") == 'y':
+        if _choice_input(prompt="Keep?", choices=['n', 'y'], io_device=io_device) == 'y':
             break
 
 
-def _calibrate_servo_range():
+def _calibrate_servo_range(io_device):
     _setup_motors()
 
     motor_params = _query_motor_params()
@@ -107,46 +138,37 @@ def _calibrate_servo_range():
     steering_mid   = motor_params['steering_mid']
     steering_right = motor_params['steering_right']
 
-    _setup_motors(30000)
-    m.set_steering(45.0)
-    v = _easy_ask("Steering left PWM value", steering_left, int)
     while True:
-        steering_left = v
         STORE.put('CAR_MOTOR_STEERING_LEFT', steering_left)
         _setup_motors(30000)  # <-- nearabout the max possible timeout
         m.set_steering(45.0)
-        v = _easy_ask("Steering left PWM value", steering_left, int)
+        v = _easy_ask("Steering left PWM value", steering_left, int, io_device)
         if v == steering_left:
             break  # break when the user doesn't change the value
+        steering_left = v
 
-    _setup_motors(30000)
-    m.set_steering(-45.0)
-    v = _easy_ask("Steering right PWM value", steering_right, int)
     while True:
-        steering_right = v
         STORE.put('CAR_MOTOR_STEERING_RIGHT', steering_right)
         _setup_motors(30000)  # <-- nearabout the max possible timeout
         m.set_steering(-45.0)
-        v = _easy_ask("Steering right PWM value", steering_right, int)
+        v = _easy_ask("Steering right PWM value", steering_right, int, io_device)
         if v == steering_right:
             break  # break when the user doesn't change the value
+        steering_right = v
 
-    _setup_motors()
-    m.set_steering(0)
-    v = _easy_ask("Steering mid PWM value", steering_mid, int)
     while True:
-        steering_mid = v
         STORE.put('CAR_MOTOR_STEERING_MID', steering_mid)
         _setup_motors()
         _demo_forward_reverse_no_pid()
-        v = _easy_ask("Steering mid PWM value", steering_mid, int)
+        v = _easy_ask("Steering mid PWM value", steering_mid, int, io_device)
         if v == steering_mid:
             break  # break when the user doesn't change the value
+        steering_mid = v
 
     _setup_motors(save=True)
 
 
-def _calibrate_steering_pid():
+def _calibrate_steering_pid(io_device):
     _setup_steering_pid()
 
     steering_pid_params = _query_steering_pid_params()
@@ -155,7 +177,11 @@ def _calibrate_steering_pid():
     d = steering_pid_params['d']
 
     while True:
-        p, i, d = _easy_ask("Steering PID [space-separated p i d]", (p, i, d), lambda s: tuple(float(v) for v in s.split(' ')))
+        p, i, d = _easy_ask("Steering PID [space-separated p i d]",
+                            [p, i, d],
+                            lambda s: (float(v) for v in s.split(' ')),
+                            io_device,
+                            adj_delta=0.1)
 
         STORE.put('CAR_STEERING_PID_P', p)
         STORE.put('CAR_STEERING_PID_I', i)
@@ -166,29 +192,161 @@ def _calibrate_steering_pid():
         m.forward(2.5)  # <-- uses gyro
         m.reverse(2.5)  # <-- uses gyro
 
-        if input("Keep? [n/y] ") == 'y':
+        if _choice_input(prompt="Keep?", choices=['n', 'y'], io_device=io_device) == 'y':
             break
 
     _setup_steering_pid(save=True)
 
 
-def calibrate():
+def calibrate(io_device=['computer', 'car'][0]):
     """
     Run the end-to-end calibration routine for this car.
     """
+    _set_globals()
 
-    if input("Calibrate microcontroller (e.g. gyro & accelerometer)? [n/y] ") == 'y':
-        _calibrate_microcontroller()
+    if _choice_input(prompt="Calibrate microcontroller (e.g. gyro & accelerometer)?",
+                     choices=['n', 'y'],
+                     io_device=io_device) == 'y':
+        _calibrate_microcontroller(io_device=io_device)
 
-    if input("Calibrate safe throttle speed? [n/y] ") == 'y':
-        _calibrate_safe_throttle()
+    if _choice_input("Calibrate safe throttle speed?",
+                     choices=['n', 'y'],
+                     io_device=io_device) == 'y':
+        _calibrate_safe_throttle(io_device)
 
-    if input("Calibrate servo range? [n/y] ") == 'y':
-        _calibrate_servo_range()
+    if _choice_input("Calibrate servo range?",
+                     choices=['n', 'y'],
+                     io_device=io_device) == 'y':
+        _calibrate_servo_range(io_device)
 
-    if input("Calibrate steering PID? [n/y] ") == 'y':
-        _calibrate_steering_pid()
+    if _choice_input("Calibrate steering PID?",
+                     choices=['n', 'y'],
+                     io_device=io_device) == 'y':
+        _calibrate_steering_pid(io_device)
 
-    if input("Disable battery monitor? [n/y] ") == 'y':
+    if _choice_input("Disable battery monitor?",
+                     choices=['n', 'y'],
+                     io_device=io_device) == 'y':
         STORE.put('BATTERY_MONITOR_DISABLED', True)
 
+    msg = 'Calibraton complete!'
+    if io_device == 'computer':
+        print(msg)
+    elif io_device == 'car':
+        c.print(msg)
+
+
+def _set_globals():
+    global _BUTTONS
+    # assign descriptions to buttons
+    _BUTTONS = {
+        'LEFT/DOWN': 3,
+        'SUBMIT'   : 2,
+        'RIGHT/UP' : 1,
+    }
+
+
+def _choice_input(prompt, choices, io_device):
+    if io_device == 'computer':
+        result = _keyboard_input(prompt=prompt, choices=choices)
+    elif io_device == 'car':
+        result = _button_choice_input(prompt=prompt, choices=choices)
+    return result
+
+
+def _keyboard_input(prompt, choices=None, curr_val=None):
+    msg_opts = msg_curr_val = ''
+    if curr_val is not None:
+        msg_curr_val = f' [or keep {curr_val}]: '
+    if choices is not None:
+        msg_opts = f" [ {' / '.join(choices)} ] "
+    response = input(prompt + msg_opts + msg_curr_val)
+    return response if response else curr_val
+
+
+def _is_pressed(button, e):
+    return e['button'] == button and e['action'] == 'pressed'
+
+
+def _is_released(button, e):
+    return e['button'] == button and e['action'] == 'released'
+
+
+def _button_choice_input(prompt, choices):
+    c.print(prompt)
+    choice_i = 0
+    decided = False
+    buttons = acquire('PushButtons')
+    while not decided:
+        events = buttons.get_events()
+        for e in events:
+            if _is_released(_BUTTONS['RIGHT/UP'], e):
+                choice_i += 1
+            elif _is_released(_BUTTONS['LEFT/DOWN'], e):
+                choice_i -= 1
+            elif _is_released(_BUTTONS['SUBMIT'], e):
+                decided = True
+                break
+            if abs(choice_i) == len(choices):
+                choice_i = 0
+        output = f"[ {' / '.join([(f'({c})' if i == abs(choice_i) else f' {c} ') for i, c in enumerate(choices)])} ]"
+        c.print(output, end='\r' if not decided else '\n')
+        time.sleep(0.05)
+    release(buttons)
+    return choices[choice_i]
+
+
+def _button_numeric_input(prompt, initial=0, adj_delta=1):
+    TIMER_RESET_VAL = 15
+    adj_factor = [1, 10, 100]  # increase increment/decrement amount by factor
+    adj = adj_rate = extra_delay = val_idx = 0
+    vals = [initial] if not isinstance(initial, list) else initial
+    val = vals[val_idx]
+    still_editing = True
+    held = False
+    c.print(prompt)
+    buttons = acquire('PushButtons')
+    while still_editing:
+        events = buttons.get_events()
+        if events:
+            for e in events:
+                if _is_released(_BUTTONS['SUBMIT'], e):
+                    if val_idx + 1 == len(vals):
+                        still_editing = False
+                    else:
+                        val_idx += 1
+                        val = vals[val_idx]
+                if _is_released(_BUTTONS['LEFT/DOWN'], e) or _is_released(_BUTTONS['RIGHT/UP'], e):
+                    held = False
+                    adj = 0
+                    adj_rate = 0
+                    extra_delay = 0
+                if _is_pressed(_BUTTONS['LEFT/DOWN'], e):
+                    held = True
+                    timer = TIMER_RESET_VAL
+                    adj = -adj_delta
+                if _is_pressed(_BUTTONS['RIGHT/UP'], e):
+                    held = True
+                    timer = TIMER_RESET_VAL
+                    adj = adj_delta
+                val += adj * adj_factor[adj_rate]
+        else:
+            val += adj * (adj_factor[adj_rate])
+        if isinstance(adj_delta, float):
+            val = round(val, len(str(adj_delta)) - 2)
+        if held:
+            if timer != 0:
+                timer -= 1
+            else:
+                if val % (10 * adj_delta) == 0:
+                    adj_rate = min([adj_rate + 1, len(adj_factor)])
+                    extra_delay = 0.50  # give more time for humans to react
+                    timer = TIMER_RESET_VAL
+        vals[val_idx] = val
+        output = f"[ {' / '.join([f'({v})' if i == val_idx else f' {v} ' for i, v in enumerate(vals)])} ]"
+        c.print(output, end='\r')
+        time.sleep(0.05 + extra_delay)
+
+    c.print('Finished choosing', vals)
+    release(buttons)
+    return vals[0] if len(vals) == 1 else ' '.join(str(v) for v in vals)

--- a/cio/components.py
+++ b/cio/components.py
@@ -138,14 +138,13 @@ def factory_calibrator(fd, reg_num):
             is running!
             """
             self._start_calibration()
-            print("Calibrating... please wait... this takes about 1 minute.\nDo not move your device while this calibration is running!")
+            yield "Calibrating... please wait... this takes about 1 minute.\nDo not move your device while this calibration is running!"
             while True:
-                time.sleep(1)
                 status = self._check_calibration_status()
                 if status == 1:
-                    print('.', end='', flush=True)
+                    yield '.'
                 elif status == 2:
-                    print("\nFinished calibrating!")
+                    yield 'Finished microcontroller calibration!'
                     break
                 else:
                     raise Exception("Got unknown status code...")

--- a/startup/console_ui/console_ui.py
+++ b/startup/console_ui/console_ui.py
@@ -108,11 +108,18 @@ def draw_header():
 
 def parse_text(new_text, old_lines, outer_rect):
 
+    if old_lines:
+        if len(old_lines[-1]) == 1 and old_lines[-1][0][0] == '\r':
+            old_lines.pop()
+            if old_lines:
+                old_lines.pop()
+            old_lines.append([])
+
     for char in new_text:
 
         if char == '\r':
+            old_lines.append([('\r', None)])
             continue
-
         sprite = console_font.render(char, True, CONSOLE_TXT_COLOR, CONSOLE_TXT_BG_COLOR)
         rect = sprite.get_rect()
 
@@ -135,6 +142,8 @@ def parse_text(new_text, old_lines, outer_rect):
 def draw_lines(lines, outer_rect):
     x, y = outer_rect.topleft
     for line in lines:
+        if len(line)==1 and line[0][0] == '\r':
+            continue
         for char, sprite in line:
             rect = sprite.get_rect()
             rect.topleft = (x, y)


### PR DESCRIPTION
To kick off the calibration, ssh into the car and run car.calibrate('car').  You can still calibrate via the computer by not passing an argument to car.calibrate(). Hopefully the interface is intuitive enough that you won't need instructions on how to use it.  Let me know of any bugs/changes.