### PR TITLE
Enable use of the encoder and gyro for the `car` module (e.g. forward, left, etc).

### DIFF
--- a/car/__init__.py
+++ b/car/__init__.py
@@ -24,77 +24,137 @@ do not print.
 """
 
 from auto import print_all as print  # override the build-in `print()`
-
 import time
 
 
-def forward(duration=1.0, verbose=True):
+def forward(sec=None, cm=None, verbose=True):
     """
-    Drive the car forward for `duration` seconds.
-    """
-    from car import motors
-    if duration > 5.0:
-        print("Error: The duration exceeds 5 seconds; will reset to 5 seconds.")
-        duration = 5.0
-    if verbose:
-        print("Driving forward for {} seconds.".format(duration))
-    if duration <= 0.0:
-        return
-    motors.straight(motors.safe_forward_throttle(), duration, invert_output=False)
-
-
-def reverse(duration=1.0, verbose=True):
-    """
-    Drive the car in reverse for `duration` seconds.
+    Drive the car forward for `sec` seconds or `cm` centimeters.
     """
     from car import motors
-    if duration > 5.0:
-        print("Error: The duration exceeds 5 seconds; will reset to 5 seconds.")
-        duration = 5.0
-    if verbose:
-        print("Driving in reverse for {} seconds.".format(duration))
-    if duration <= 0.0:
+
+    if sec and cm:
+        print("Error: Please specify duration (sec) OR distance (cm) - not both.")
         return
-    motors.straight(motors.safe_reverse_throttle(), duration, invert_output=True)
+    if sec is None and cm is None:
+        sec = 1.0
+
+    if sec:
+        if sec > 5.0:
+            print("Error: The duration (sec) exceeds 5 seconds; will reset to 5 seconds.")
+            sec = 5.0
+        if sec <= 0.0:
+            return
+        if sec and verbose:
+            print("Driving forward for {} seconds.".format(sec))
+
+    if cm:
+        if cm <= 0.0:
+            return
+        if cm and verbose:
+            print("Driving forward for {} centimeters.".format(cm))
+
+    motors.straight(motors.safe_forward_throttle(), sec, cm, invert_output=False)
 
 
-def left(duration=1.0, verbose=True):
+def reverse(sec=None, cm=None, verbose=True):
     """
-    Drive the car forward and left for `duration` seconds.
+    Drive the car in reverse for `sec` seconds or `cm` centimeters.
     """
     from car import motors
-    if duration > 5.0:
-        print("Error: The duration exceeds 5 seconds; will reset to 5 seconds.")
-        duration = 5.0
-    if verbose:
-        print("Driving left for {} seconds.".format(duration))
-    if duration <= 0.0:
+
+    if sec and cm:
+        print("Error: Please specify duration (sec) OR distance (cm) - not both.")
         return
-    motors.drive(45.0, motors.safe_forward_throttle(), duration)
+    if sec is None and cm is None:
+        sec = 1.0
+
+    if sec:
+        if sec > 5.0:
+            print("Error: The duration (sec) exceeds 5 seconds; will reset to 5 seconds.")
+            sec = 5.0
+        if sec <= 0.0:
+            return
+        if sec and verbose:
+            print("Driving in reverse for {} seconds.".format(sec))
+
+    if cm:
+        if cm <= 0.0:
+            return
+        if cm and verbose:
+            print("Driving in reverse for {} centimeters.".format(cm))
+        cm = -cm
+
+    motors.straight(motors.safe_reverse_throttle(), sec, cm, invert_output=True, forward=False)
 
 
-def right(duration=1.0, verbose=True):
+def left(sec=None, deg=None, verbose=True):
     """
-    Drive the car forward and right for `duration` seconds.
+    Drive the car forward and left for `sec` seconds or `deg` degrees.
     """
     from car import motors
-    if duration > 5.0:
-        print("Error: The duration exceeds 5 seconds; will reset to 5 seconds.")
-        duration = 5.0
-    if verbose:
-        print("Driving right for {} seconds.".format(duration))
-    if duration <= 0.0:
+
+    if sec and deg:
+        print("Error: Please specify duration (sec) OR degrees (deg) - not both.")
         return
-    motors.drive(-45.0, motors.safe_forward_throttle(), duration)
+    if sec is None and deg is None:
+        sec = 1.0
+
+    if sec:
+        if sec > 5.0:
+            print("Error: The duration (sec) exceeds 5 seconds; will reset to 5 seconds.")
+            sec = 5.0
+        if verbose:
+            print("Driving left for {} seconds.".format(sec))
+        if sec <= 0.0:
+            return
+
+    if deg:
+        if deg <= 0.0:
+            return
+        if deg and verbose:
+            print("Driving left for {} degrees.".format(deg))
+
+    motors.drive(45.0, motors.safe_forward_throttle(), sec, deg)
 
 
-def pause(duration=1.0, verbose=True):
+def right(sec=None, deg=None, verbose=True):
     """
-    Pause the car's code for `duration` seconds.
+    Drive the car forward and right for `sec` seconds or `deg` degrees.
+    """
+    from car import motors
+
+    if sec and deg:
+        print("Error: Please specify duration (sec) OR degrees (deg) - not both.")
+        return
+    if sec is None and deg is None:
+        sec = 1.0
+
+    if sec:
+        if sec > 5.0:
+            print("Error: The duration (sec) exceeds 5 seconds; will reset to 5 seconds.")
+            sec = 5.0
+        if verbose:
+            print("Driving right for {} seconds.".format(sec))
+        if sec <= 0.0:
+            return
+
+    if deg:
+        if deg <= 0.0:
+            return
+        if deg and verbose:
+            print("Driving right for {} degrees.".format(deg))
+
+    motors.drive(-45.0, motors.safe_forward_throttle(), sec, deg)
+
+
+def pause(sec=1.0, verbose=True):
+    """
+    Pause the car's code for `sec` seconds.
     """
     if verbose:
-        print("Pausing for {} seconds.".format(duration))
-    time.sleep(duration)
+        print("Pausing for {} seconds.".format(sec))
+    time.sleep(sec)
 
 
 def capture(num_frames=1, verbose=True):

--- a/car/__init__.py
+++ b/car/__init__.py
@@ -29,11 +29,12 @@ import time
 
 def forward(sec=None, cm=None, verbose=True):
     """
-    Drive the car forward for `sec` seconds or `cm` centimeters.
+    Drive the car forward for `sec` seconds or `cm` centimeters (passing in both
+    will raise an error). If neither is passed in, the car will drive for 1 second.
     """
     from car import motors
 
-    if sec and cm:
+    if sec is not None and cm is not None:
         print("Error: Please specify duration (sec) OR distance (cm) - not both.")
         return
     if sec is None and cm is None:
@@ -45,13 +46,16 @@ def forward(sec=None, cm=None, verbose=True):
             sec = 5.0
         if sec <= 0.0:
             return
-        if sec and verbose:
+        if verbose:
             print("Driving forward for {} seconds.".format(sec))
 
-    if cm:
+    if cm is not None:
+        if cm > 300.0:
+            print("Error: The distance (cm) exceeds 300 cm (~10 feet); will reset to 300 cm.")
+            cm = 300.0
         if cm <= 0.0:
             return
-        if cm and verbose:
+        if verbose:
             print("Driving forward for {} centimeters.".format(cm))
 
     motors.straight(motors.safe_forward_throttle(), sec, cm, invert_output=False)
@@ -59,11 +63,12 @@ def forward(sec=None, cm=None, verbose=True):
 
 def reverse(sec=None, cm=None, verbose=True):
     """
-    Drive the car in reverse for `sec` seconds or `cm` centimeters.
+    Drive the car in reverse for `sec` seconds or `cm` centimeters (passing in both
+    will raise an error). If neither is passed in, the car will drive for 1 second.
     """
     from car import motors
 
-    if sec and cm:
+    if sec is not None and cm is not None:
         print("Error: Please specify duration (sec) OR distance (cm) - not both.")
         return
     if sec is None and cm is None:
@@ -75,13 +80,16 @@ def reverse(sec=None, cm=None, verbose=True):
             sec = 5.0
         if sec <= 0.0:
             return
-        if sec and verbose:
+        if verbose:
             print("Driving in reverse for {} seconds.".format(sec))
 
-    if cm:
+    if cm is not None:
+        if cm > 300.0:
+            print("Error: The distance (cm) exceeds 300 cm (~10 feet); will reset to 300 cm.")
+            cm = 300.0
         if cm <= 0.0:
             return
-        if cm and verbose:
+        if verbose:
             print("Driving in reverse for {} centimeters.".format(cm))
         cm = -cm
 
@@ -90,11 +98,12 @@ def reverse(sec=None, cm=None, verbose=True):
 
 def left(sec=None, deg=None, verbose=True):
     """
-    Drive the car forward and left for `sec` seconds or `deg` degrees.
+    Drive the car forward and left for `sec` seconds or `deg` degrees (passing in both
+    will raise an error). If neither is passed in, the car will drive for 1 second.
     """
     from car import motors
 
-    if sec and deg:
+    if sec is not None and deg is not None:
         print("Error: Please specify duration (sec) OR degrees (deg) - not both.")
         return
     if sec is None and deg is None:
@@ -104,15 +113,18 @@ def left(sec=None, deg=None, verbose=True):
         if sec > 5.0:
             print("Error: The duration (sec) exceeds 5 seconds; will reset to 5 seconds.")
             sec = 5.0
-        if verbose:
-            print("Driving left for {} seconds.".format(sec))
         if sec <= 0.0:
             return
+        if verbose:
+            print("Driving left for {} seconds.".format(sec))
 
-    if deg:
+    if deg is not None:
+        if deg > 360.0:
+            print("Error: The degrees (deg) exceeds 360; will reset to 360.")
+            cm = 360.0
         if deg <= 0.0:
             return
-        if deg and verbose:
+        if verbose:
             print("Driving left for {} degrees.".format(deg))
 
     motors.drive(45.0, motors.safe_forward_throttle(), sec, deg)
@@ -120,11 +132,12 @@ def left(sec=None, deg=None, verbose=True):
 
 def right(sec=None, deg=None, verbose=True):
     """
-    Drive the car forward and right for `sec` seconds or `deg` degrees.
+    Drive the car forwad and right for `sec` seconds or `deg` degrees (passing in both
+    will raise an error). If neither is passed in, the car will drive for 1 second.
     """
     from car import motors
 
-    if sec and deg:
+    if sec is not None and deg is not None:
         print("Error: Please specify duration (sec) OR degrees (deg) - not both.")
         return
     if sec is None and deg is None:
@@ -134,15 +147,18 @@ def right(sec=None, deg=None, verbose=True):
         if sec > 5.0:
             print("Error: The duration (sec) exceeds 5 seconds; will reset to 5 seconds.")
             sec = 5.0
-        if verbose:
-            print("Driving right for {} seconds.".format(sec))
         if sec <= 0.0:
             return
+        if verbose:
+            print("Driving right for {} seconds.".format(sec))
 
-    if deg:
+    if deg is not None:
+        if deg > 360.0:
+            print("Error: The degrees (deg) exceeds 360; will reset to 360.")
+            cm = 360.0
         if deg <= 0.0:
             return
-        if deg and verbose:
+        if verbose:
             print("Driving right for {} degrees.".format(deg))
 
     motors.drive(-45.0, motors.safe_forward_throttle(), sec, deg)

--- a/car/motors.py
+++ b/car/motors.py
@@ -21,6 +21,8 @@ import time
 WHEEL_CIRCUMFERENCE = 197.92    # in millimeters
 MOTOR_RATIO = 100               # e.g. if "100:1", then just 100
 ENCODER_CPR = 28                # the encoder's counts per revolution
+INVERT_ENCODER = -1             # 1 or -1; specific to how the encoder is insatlled
+
 
 enc = acquire('Encoders')
 enc.enable(1)
@@ -149,7 +151,7 @@ def get_current_distance():
     # Convert `curr_count` to linear distance.
     curr_distance = (curr_count / ENCODER_CPR) * (WHEEL_CIRCUMFERENCE / MOTOR_RATIO)
 
-    return -curr_distance
+    return curr_distance * INVERT_ENCODER
 
 
 def get_current_degrees():


### PR DESCRIPTION
**Highlights**
- `car.forward()` and `car.reverse()` can now accept `sec` (seconds) or `cm` (centimeters).
- `car.left()` and `car.right()` can now accept `sec` (seconds) or `deg` (degrees, i.e. the degree of turn to take).

**Revisit later**
To make use of the encoder, we need the following hardware specs from the motor and encoder to properly convert values between the encoder's readings and linear distance:
- `WHEEL_CIRCUMFERENCE`
- `MOTOR_RATIO` (the motor's gear ratio, e.g. 100:1)
- `ENCODER_CPR` (the encoder's counts per revolution)

For now, these values need to be hardcoded in `car.motors.py`. We may want to eventually implement a config file where users can specify these (and other) specs that are specific to their devices and contexts.

**Testing**
I successfully tested the changes using the following commands.
```
import car

# Original functionality
car.forward()  # With no args specified, defaults to 1.0 seconds.
car.reverse()
car.left()
car.right()
car.pause(sec=1.0)
car.forward(sec=1.5)
car.reverse(sec=1.5)
car.left(sec=1)
car.right(sec=1)

# New stuff
car.forward(cm=10)
car.reverse(cm=20)
car.left(deg=45)
car.right(deg=45)
car.left(deg=90)
car.right(deg=90)
```