### PR TITLE
Removed negation of 'cm' in reverse().

### DIFF
--- a/car/__init__.py
+++ b/car/__init__.py
@@ -93,7 +93,6 @@ def reverse(sec=None, cm=None, verbose=True):
             return
         if verbose:
             print("Driving in reverse for {} centimeters.".format(cm))
-        cm = -cm
 
     motors.straight(motors.safe_reverse_throttle(), sec, cm, invert_output=True)
 


### PR DESCRIPTION
The following currently does nothing:
```
reverse(cm=10)
```
Removing the `cm = -cm` line in `reverse()` fixes this. The negation seems to no longer be needed.

Here's the "test suite" I ran with the car:
```
import car

# Original functions
car.forward()
car.reverse()
car.left()
car.right()
car.pause(sec=1.0)
car.forward(sec=1.5)
car.reverse(sec=1.5)
car.left(sec=1)
car.right(sec=1)

# New stuff
car.forward(cm=10)
car.reverse(cm=20)
car.left(deg=45)
car.right(deg=45)
car.left(deg=90)
car.right(deg=90)
```